### PR TITLE
Trim whitespace from code128 barcode pixelmap

### DIFF
--- a/README_CODE128_TRIM.md
+++ b/README_CODE128_TRIM.md
@@ -1,0 +1,22 @@
+## Code128 Margin Trimming for HarmonyOS PixelMap
+
+This module provides a function to trim left/right white margins of Code128 barcodes by scanning for black pixels and cropping the `PixelMap` accordingly.
+
+### API
+
+- `dealWithCodel128(pixelMap, option): Promise<PixelMap>`
+  - Only acts when `option.scanType === scanCore.ScanType.CODE128_CODE`.
+  - Returns a new `PixelMap` cropped horizontally to remove leading/trailing white margins.
+
+- `trimHorizontalMarginsByBlack(pixelMap, blackThreshold?): Promise<PixelMap>`
+  - Generic helper using a luminance threshold (default 48).
+
+### Self-test
+
+Run `runSelfTest()` from `src/code128Trim/selftest.ts` inside a Harmony environment. It synthesizes a barcode-like image with left/right margins, runs the trimming, and asserts output width.
+
+### Notes
+
+- Pixel formats supported: `RGBA_8888`, `BGRA_8888`, `ARGB_8888`. Others default to RGBA interpretation.
+- Threshold may need tuning if the barcode is not pure black.
+

--- a/src/code128Trim/selftest.ts
+++ b/src/code128Trim/selftest.ts
@@ -1,0 +1,63 @@
+import image from '@ohos.multimedia.image';
+import { dealWithCodel128, scanCore } from './trim';
+
+async function createSyntheticBarcodePixelMap(
+  totalWidth: number,
+  height: number,
+  leftMargin: number,
+  rightMargin: number,
+  barWidth: number
+): Promise<image.PixelMap> {
+  const pixelFormat = image.PixelMapFormat.RGBA_8888;
+  const bytesPerPixel = 4;
+  const bytes = new Uint8Array(totalWidth * height * bytesPerPixel);
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < totalWidth; x++) {
+      const i = (y * totalWidth + x) * bytesPerPixel;
+      let isBlack = false;
+      if (x >= leftMargin && x < totalWidth - rightMargin) {
+        const relative = x - leftMargin;
+        isBlack = Math.floor(relative / barWidth) % 2 === 0; // alternate bars
+      }
+      bytes[i + 0] = isBlack ? 0 : 255; // R
+      bytes[i + 1] = isBlack ? 0 : 255; // G
+      bytes[i + 2] = isBlack ? 0 : 255; // B
+      bytes[i + 3] = 255; // A
+    }
+  }
+
+  const pm = await image.createPixelMap(bytes.buffer, {
+    size: { width: totalWidth, height },
+    pixelFormat,
+    editable: true,
+  });
+  return pm;
+}
+
+export async function runSelfTest(): Promise<void> {
+  const totalWidth = 400;
+  const height = 120;
+  const leftMargin = 40;
+  const rightMargin = 60;
+  const barWidth = 3;
+
+  const pixelMap = await createSyntheticBarcodePixelMap(
+    totalWidth,
+    height,
+    leftMargin,
+    rightMargin,
+    barWidth
+  );
+
+  const processed = await dealWithCodel128(pixelMap, { scanType: scanCore.ScanType.CODE128_CODE });
+
+  const info = await processed.getImageInfo();
+  const expectedWidth = totalWidth - leftMargin - rightMargin;
+  if (info.size.width !== expectedWidth || info.size.height !== height) {
+    throw new Error(
+      `SelfTest failed: got ${info.size.width}x${info.size.height}, expected ${expectedWidth}x${height}`
+    );
+  }
+}
+

--- a/src/code128Trim/trim.ts
+++ b/src/code128Trim/trim.ts
@@ -1,0 +1,195 @@
+/*
+ * Code128 margin trimming utilities for HarmonyOS PixelMap
+ */
+
+import image from '@ohos.multimedia.image';
+
+// Minimal types to avoid leaking external dependencies at compile time
+// Adjust imports/types in your project if you already have them defined elsewhere
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace scanCore {
+  export enum ScanType {
+    CODE128_CODE = 104,
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace generateBarcode {
+  export interface CreateOptions {
+    scanType: number;
+  }
+}
+
+type ChannelOffsets = {
+  redOffset: number;
+  greenOffset: number;
+  blueOffset: number;
+  alphaOffset: number;
+  bytesPerPixel: number;
+};
+
+function getChannelOffsets(pixelFormat: number): ChannelOffsets {
+  // Default to RGBA_8888 if unknown; supported formats handled explicitly
+  switch (pixelFormat) {
+    case image.PixelMapFormat.RGBA_8888:
+      return { redOffset: 0, greenOffset: 1, blueOffset: 2, alphaOffset: 3, bytesPerPixel: 4 };
+    case image.PixelMapFormat.BGRA_8888:
+      return { redOffset: 2, greenOffset: 1, blueOffset: 0, alphaOffset: 3, bytesPerPixel: 4 };
+    case image.PixelMapFormat.ARGB_8888:
+      return { redOffset: 1, greenOffset: 2, blueOffset: 3, alphaOffset: 0, bytesPerPixel: 4 };
+    default:
+      // Fall back to RGBA_8888 interpretation
+      return { redOffset: 0, greenOffset: 1, blueOffset: 2, alphaOffset: 3, bytesPerPixel: 4 };
+  }
+}
+
+function isBlackPixel(
+  pixelBytes: Uint8Array,
+  indexBase: number,
+  offsets: ChannelOffsets,
+  blackThreshold: number
+): boolean {
+  const red = pixelBytes[indexBase + offsets.redOffset];
+  const green = pixelBytes[indexBase + offsets.greenOffset];
+  const blue = pixelBytes[indexBase + offsets.blueOffset];
+  const luminance = (red + green + blue) / 3;
+  return luminance <= blackThreshold;
+}
+
+function scanEffectiveHorizontalBounds(
+  pixelBytes: Uint8Array,
+  width: number,
+  height: number,
+  offsets: ChannelOffsets,
+  blackThreshold: number
+): { left: number; right: number } | null {
+  let left = -1;
+  let right = -1;
+
+  for (let x = 0; x < width; x++) {
+    let hasBlack = false;
+    for (let y = 0; y < height; y++) {
+      const index = (y * width + x) * offsets.bytesPerPixel;
+      if (isBlackPixel(pixelBytes, index, offsets, blackThreshold)) {
+        hasBlack = true;
+        break;
+      }
+    }
+    if (hasBlack) {
+      left = x;
+      break;
+    }
+  }
+
+  for (let x = width - 1; x >= 0; x--) {
+    let hasBlack = false;
+    for (let y = 0; y < height; y++) {
+      const index = (y * width + x) * offsets.bytesPerPixel;
+      if (isBlackPixel(pixelBytes, index, offsets, blackThreshold)) {
+        hasBlack = true;
+        break;
+      }
+    }
+    if (hasBlack) {
+      right = x;
+      break;
+    }
+  }
+
+  if (left < 0 || right < 0 || right < left) {
+    return null;
+  }
+  return { left, right };
+}
+
+async function readPixelBytes(pm: image.PixelMap): Promise<{
+  bytes: Uint8Array;
+  width: number;
+  height: number;
+  pixelFormat: number;
+}> {
+  const info = await pm.getImageInfo();
+  const width = info.size.width;
+  const height = info.size.height;
+  const byteCount = pm.getPixelBytesNumber();
+  const buffer = new ArrayBuffer(byteCount);
+  await pm.readPixelsToBuffer(buffer);
+  const bytes = new Uint8Array(buffer);
+  const pixelFormat = info.pixelFormat ?? image.PixelMapFormat.RGBA_8888;
+  return { bytes, width, height, pixelFormat };
+}
+
+async function createPixelMap(
+  bytes: Uint8Array,
+  width: number,
+  height: number,
+  pixelFormat: number
+): Promise<image.PixelMap> {
+  const buffer = bytes.buffer.byteLength === bytes.byteLength && bytes.byteOffset === 0
+    ? bytes.buffer
+    : bytes.slice().buffer;
+
+  return await image.createPixelMap(buffer, {
+    size: { width, height },
+    pixelFormat: pixelFormat,
+    editable: true,
+  });
+}
+
+export async function dealWithCodel128(
+  pixelMap: image.PixelMap,
+  option: generateBarcode.CreateOptions
+): Promise<image.PixelMap> {
+  if (option?.scanType !== scanCore.ScanType.CODE128_CODE) {
+    return pixelMap;
+  }
+
+  const { bytes, width, height, pixelFormat } = await readPixelBytes(pixelMap);
+  const offsets = getChannelOffsets(pixelFormat);
+
+  const bounds = scanEffectiveHorizontalBounds(bytes, width, height, offsets, 48);
+  if (!bounds) {
+    return pixelMap;
+  }
+
+  const newWidth = bounds.right - bounds.left + 1;
+  if (newWidth <= 0 || newWidth === width) {
+    return pixelMap;
+  }
+
+  const cropped = new Uint8Array(newWidth * height * offsets.bytesPerPixel);
+  for (let y = 0; y < height; y++) {
+    const srcRowStart = (y * width + bounds.left) * offsets.bytesPerPixel;
+    const dstRowStart = (y * newWidth) * offsets.bytesPerPixel;
+    const rowLength = newWidth * offsets.bytesPerPixel;
+    cropped.set(bytes.subarray(srcRowStart, srcRowStart + rowLength), dstRowStart);
+  }
+
+  const newPm = await createPixelMap(cropped, newWidth, height, pixelFormat);
+  return newPm;
+}
+
+export async function trimHorizontalMarginsByBlack(
+  pixelMap: image.PixelMap,
+  blackThreshold: number = 48
+): Promise<image.PixelMap> {
+  const { bytes, width, height, pixelFormat } = await readPixelBytes(pixelMap);
+  const offsets = getChannelOffsets(pixelFormat);
+  const bounds = scanEffectiveHorizontalBounds(bytes, width, height, offsets, blackThreshold);
+  if (!bounds) {
+    return pixelMap;
+  }
+  const newWidth = bounds.right - bounds.left + 1;
+  if (newWidth <= 0 || newWidth === width) {
+    return pixelMap;
+  }
+  const cropped = new Uint8Array(newWidth * height * offsets.bytesPerPixel);
+  for (let y = 0; y < height; y++) {
+    const srcRowStart = (y * width + bounds.left) * offsets.bytesPerPixel;
+    const dstRowStart = (y * newWidth) * offsets.bytesPerPixel;
+    const rowLength = newWidth * offsets.bytesPerPixel;
+    cropped.set(bytes.subarray(srcRowStart, srcRowStart + rowLength), dstRowStart);
+  }
+  return await createPixelMap(cropped, newWidth, height, pixelFormat);
+}
+


### PR DESCRIPTION
Implement horizontal margin trimming for Code128 `PixelMap` to remove uncontrolled white margins.

---
<a href="https://cursor.com/background-agent?bcId=bc-c33a53a2-dfaf-4975-ad38-77420cffe1d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c33a53a2-dfaf-4975-ad38-77420cffe1d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

